### PR TITLE
Don't treat all warnings (including deprecations) as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OS		:= $(shell uname | tr '/[[:lower:]]' '_[[:upper:]]')
 
 # These are the specifications of the toolchain
 CC		:= gcc
-CFLAGS		:= -std=c89 -g -oS -Wall -Werror -Wno-deprecated
+CFLAGS		:= -std=c89 -g -oS -Wall -Wno-deprecated
 CPPFLAGS	:= -D_DEFAULT_SOURCE -D$(OS) $(WHIRLPOOL)
 ifeq ($(OS),DARWIN)
     LDFLAGS		:= -lssl -lcrypto -L/usr/local/opt/openssl/lib/


### PR DESCRIPTION
OpenSSL 3.0 has deprecated several functions used here, so let's not treat those deprecation warnings as errors.

Fix #1